### PR TITLE
docs: add codesandbox to issue template for easier minimal reproduction of bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -33,9 +33,10 @@ Tell us how to reproduce this issue.  Please provide a working and simplified ex
 🎉 BONUS POINTS for creating a [minimal reproduction](https://stackoverflow.com/help/mcve) and uploading it to GitHub.  This will get you the fastest support.  🎉
 
 <!--
-Consider using a codesandbox to make the issue easy to replicate, here are two starters:
-https://codesandbox.io/s/remark-debug-ikwvx
-https://codesandbox.io/s/react-markdown-debug-9n4eg
+Consider using a codesandbox to make the issue easy to replicate, here are some starters:
+remark only (for markdown to markdown): https://codesandbox.io/s/remark-debug-ikwvx
+remark and rehype (for markdown to html): https://codesandbox.io/s/remark-rehype-debug-4cz8v
+react-markdown: https://codesandbox.io/s/react-markdown-debug-9n4eg
 --->
 
 ### Expected behavior

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -32,6 +32,12 @@ Tell us how to reproduce this issue.  Please provide a working and simplified ex
 
 🎉 BONUS POINTS for creating a [minimal reproduction](https://stackoverflow.com/help/mcve) and uploading it to GitHub.  This will get you the fastest support.  🎉
 
+<!--
+Consider using a codesandbox to make the issue easy to replicate, here are two starters:
+https://codesandbox.io/s/remark-debug-ikwvx
+https://codesandbox.io/s/react-markdown-debug-9n4eg
+--->
+
 ### Expected behavior
 
 What should happen?


### PR DESCRIPTION
With many issues it can be difficult to get a clear understanding of what is broken, from a code sample.
Samples are often incomplete, and may not have all the context needed to replicate and understand the issue.
Codesandbox (or another sandbox tool) can help by providing a clean and shareable environment to demonstrate an issue.